### PR TITLE
config: add/remove_cumulative_overrides needs list

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -543,17 +543,17 @@ class Config(object):
                 for attr, cumulatives in self.cumulative_overrides.iteritems():
                     if 'target.'+attr in overrides:
                         cumulatives.strict_cumulative_overrides(
-                            overrides['target.'+attr])
+                            [overrides['target.'+attr]])
                         del overrides['target.'+attr]
 
                     if 'target.'+attr+'_add' in overrides:
                         cumulatives.add_cumulative_overrides(
-                            overrides['target.'+attr+'_add'])
+                            [overrides['target.'+attr+'_add']])
                         del overrides['target.'+attr+'_add']
 
                     if 'target.'+attr+'_remove' in overrides:
                         cumulatives.remove_cumulative_overrides(
-                            overrides['target.'+attr+'_remove'])
+                            [overrides['target.'+attr+'_remove']])
                         del overrides['target.'+attr+'_remove']
 
                 # Consider the others as overrides


### PR DESCRIPTION
Without this change, calls to add/remove_cumulative_overrides end up
iterating over each letter of a string rather than the override macro itself.

This was discovered trying to use the following syntax in mbed_app.json

```
{
     "target_overrides": {
        "*": {
            "target.macros_remove": "CONFIG_GPIO_AS_PINRESET"
        }
     }
}
```

...so if this syntax is incorrect, then this patch probably is likely incorrect too.
